### PR TITLE
Added asynchronous client to prevent deadlocking

### DIFF
--- a/src/HelpScoutClient.cs
+++ b/src/HelpScoutClient.cs
@@ -381,10 +381,12 @@ namespace HelpScoutNet
 
         #region Happiness
 
-        private void GetHappinessOverall()
-        {
-            //Not Implimented
-        }
+        //Not implimented yet, it requires a user compare request which makes no sense for an overall report.
+        //private Model.Report.Happiness.HappinessReport GetHappinessOverall()
+        //{
+
+        //    string endpoint = string.Format("reports/happiness.json");
+        //}
 
         private Paged<Model.Report.Common.Rating> GetHappinessRatings(Request.Report.PagedRatingsRequest requestArg)
         {

--- a/src/HelpScoutClient.cs
+++ b/src/HelpScoutClient.cs
@@ -386,9 +386,10 @@ namespace HelpScoutNet
             //Not Implimented
         }
 
-        private void GetHappinessRatings()
+        private Paged<Model.Report.Common.Rating> GetHappinessRatings(Request.Report.PagedRatingsRequest requestArg)
         {
-            //Not Implimented
+            string endpoint = string.Format("reports/happiness/ratings.json");
+            return Get<Paged<Model.Report.Common.Rating>>(endpoint, requestArg);
         }
 
         #endregion

--- a/src/HelpScoutClientAsync.cs
+++ b/src/HelpScoutClientAsync.cs
@@ -1,22 +1,21 @@
-﻿using System;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Runtime.Remoting;
-using System.Text;
-using HelpScoutNet.Model;
+﻿using HelpScoutNet.Model;
 using HelpScoutNet.Model.Report;
 using HelpScoutNet.Request;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
-using HelpScoutNet.Request.Report;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace HelpScoutNet
 {
-    public sealed class HelpScoutClient
+    public sealed class HelpScoutClientAsync
     {
         private readonly string _apiKey;
         private const string BaseUrl = "https://api.helpscout.net/v1/";
@@ -31,23 +30,23 @@ namespace HelpScoutNet
                     ContractResolver = new CamelCasePropertyNamesContractResolver(),
                     NullValueHandling = NullValueHandling.Ignore,
                     DefaultValueHandling = DefaultValueHandling.Ignore,
-                    DateFormatHandling = DateFormatHandling.IsoDateFormat,                    
+                    DateFormatHandling = DateFormatHandling.IsoDateFormat,
                 };
-                serializer.Converters.Add(new StringEnumConverter {CamelCaseText = true});
+                serializer.Converters.Add(new StringEnumConverter { CamelCaseText = true });
 
                 return serializer;
             }
         }
 
-        public HelpScoutClient(string apiKey)
+        public HelpScoutClientAsync(string apiKey)
         {
             _apiKey = apiKey;
         }
 
-        public HelpScoutClient(string apiKey, int timeoutSeconds)
+        public HelpScoutClientAsync(string apiKey, int timeoutSeconds)
         {
             _apiKey = apiKey;
-            this. timeoutSeconds = timeoutSeconds;
+            this.timeoutSeconds = timeoutSeconds;
         }
 
         #region Mailboxes
@@ -55,7 +54,7 @@ namespace HelpScoutNet
         {
             return Get<Paged<Mailbox>>("mailboxes.json", requestArg);
         }
-        
+
         public Mailbox GetMailbox(int mailboxId, FieldRequest requestArg = null)
         {
             var singleItem = Get<SingleItem<Mailbox>>(string.Format("mailboxes/{0}.json", mailboxId), requestArg);
@@ -65,7 +64,7 @@ namespace HelpScoutNet
 
         public Paged<Folder> GetFolder(int folderId, PageRequest requestArg = null)
         {
-            return Get<Paged<Folder>>(string.Format("/mailboxes/{0}/folders.json", folderId), requestArg);            
+            return Get<Paged<Folder>>(string.Format("/mailboxes/{0}/folders.json", folderId), requestArg);
         }
         #endregion
 
@@ -73,7 +72,7 @@ namespace HelpScoutNet
 
         public Paged<Conversation> ListConversations(int mailboxId, ConversationRequest requestArg = null)
         {
-            
+
             string endpoint = string.Format("mailboxes/{0}/conversations.json", mailboxId);
 
             return Get<Paged<Conversation>>(endpoint, requestArg);
@@ -87,7 +86,7 @@ namespace HelpScoutNet
         }
 
         public Paged<Conversation> ListConversationsForCustomer(int mailboxId, int customerId, ConversationRequest requestArg = null)
-        {            
+        {
             string endpoint = string.Format("mailboxes/{0}/customers/{1}/conversations.json", mailboxId, customerId);
 
             return Get<Paged<Conversation>>(endpoint, requestArg);
@@ -114,7 +113,7 @@ namespace HelpScoutNet
         public Conversation CreateConversation(Conversation conversation, bool imported = false, bool autoReply = false, bool reload = true)
         {
             string endpoint = "conversations.json";
-            return Post(endpoint, conversation, new CreateCustomerRequest{AutoReply = autoReply, Reload = reload, Imported = imported});
+            return Post(endpoint, conversation, new CreateCustomerRequest { AutoReply = autoReply, Reload = reload, Imported = imported });
         }
 
         public Conversation UpdateConversation(Conversation conversation, bool reload = true)
@@ -139,7 +138,7 @@ namespace HelpScoutNet
 
         public Thread CreateThread(int conversationId, Thread thread, bool imported = false, bool reload = true)
         {
-            string endpoint = string.Format("conversations/{0}.json",conversationId);
+            string endpoint = string.Format("conversations/{0}.json", conversationId);
 
             return Post(endpoint, thread, new PostOrPutRequest { Reload = reload, Imported = imported });
         }
@@ -207,7 +206,7 @@ namespace HelpScoutNet
         {
             string endpoint = string.Format("customers/{0}.json", customerId);
 
-            return Put(endpoint, customer, new PostOrPutRequest{ Reload = reload});
+            return Put(endpoint, customer, new PostOrPutRequest { Reload = reload });
         }
         #endregion
 
@@ -266,7 +265,7 @@ namespace HelpScoutNet
 
         public Paged<HelpScoutNet.Model.User> ListUserPerMailbox(int mailboxId, FieldRequest requestArg)
         {
-            string endpoint = string.Format("mailboxes/{0}/users.json",mailboxId);
+            string endpoint = string.Format("mailboxes/{0}/users.json", mailboxId);
 
             return Get<Paged<HelpScoutNet.Model.User>>(endpoint, requestArg);
         }
@@ -281,7 +280,7 @@ namespace HelpScoutNet
 
             return Get<Paged<Workflow>>(endpoint, requestArg);
         }
-        
+
         #endregion
 
         #region Reports
@@ -486,7 +485,7 @@ namespace HelpScoutNet
             throw new HelpScoutApiException(error, body);
         }
 
-        private T Post<T>(string endpoint, T payload, IPostOrPutRequest request) 
+        private T Post<T>(string endpoint, T payload, IPostOrPutRequest request)
         {
             var client = InitHttpClient();
 
@@ -506,13 +505,13 @@ namespace HelpScoutNet
                 else
                 {
                     return payload;
-                }  
+                }
             }
-            
+
             var error = JsonConvert.DeserializeObject<HelpScoutError>(body);
             throw new HelpScoutApiException(error, body);
         }
-        
+
         private T Put<T>(string endpoint, T payload, IPostOrPutRequest request)
         {
             var client = InitHttpClient();
@@ -522,7 +521,7 @@ namespace HelpScoutNet
 
             HttpResponseMessage response = client.PutAsync(BaseUrl + endpoint + ToQueryString(request), new StringContent(jsonPayload, Encoding.UTF8, "application/json")).Result;
             string body = response.Content.ReadAsStringAsync().Result;
-            
+
             if (response.IsSuccessStatusCode)
             {
                 if (request.Reload)
@@ -533,7 +532,7 @@ namespace HelpScoutNet
                 else
                 {
                     return payload;
-                }                
+                }
             }
 
             var error = JsonConvert.DeserializeObject<HelpScoutError>(body);
@@ -566,13 +565,13 @@ namespace HelpScoutNet
 
         private static string ToQueryString(IRequest request)
         {
-            NameValueCollection nvc = null;            
+            NameValueCollection nvc = null;
             if (request != null)
             {
                 nvc = request.ToNameValueCollection();
             }
-                
-            if(nvc == null) 
+
+            if (nvc == null)
                 return string.Empty;
 
             var array = (from key in nvc.AllKeys
@@ -582,4 +581,9 @@ namespace HelpScoutNet
             return "?" + string.Join("&", array);
         }
     }
+
+    //internal class SingleItem<T>
+    //{
+    //    public T Item { get; set; }
+    //}
 }

--- a/src/HelpScoutClientAsync.cs
+++ b/src/HelpScoutClientAsync.cs
@@ -13,6 +13,8 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 
+//.NET 4.5+ only
+
 namespace HelpScoutNet
 {
     public sealed class HelpScoutClientAsync
@@ -50,76 +52,75 @@ namespace HelpScoutNet
         }
 
         #region Mailboxes
-        public Paged<Mailbox> ListMailboxes(PageRequest requestArg = null)
+        public async Task<Paged<Mailbox>> ListMailboxes(PageRequest requestArg = null)
         {
-            return Get<Paged<Mailbox>>("mailboxes.json", requestArg);
+            return await Get<Paged<Mailbox>>("mailboxes.json", requestArg);
         }
 
-        public Mailbox GetMailbox(int mailboxId, FieldRequest requestArg = null)
+        public async Task<SingleItem<Mailbox>> GetMailbox(int mailboxId, FieldRequest requestArg = null)
         {
-            var singleItem = Get<SingleItem<Mailbox>>(string.Format("mailboxes/{0}.json", mailboxId), requestArg);
+            var singleItem = await Get<SingleItem<Mailbox>>(string.Format("mailboxes/{0}.json", mailboxId), requestArg);
 
-            return singleItem.Item;
+            return singleItem;
         }
 
-        public Paged<Folder> GetFolder(int folderId, PageRequest requestArg = null)
+        public async Task<Paged<Folder>> GetFolder(int folderId, PageRequest requestArg = null)
         {
-            return Get<Paged<Folder>>(string.Format("/mailboxes/{0}/folders.json", folderId), requestArg);
+            return await Get<Paged<Folder>>(string.Format("/mailboxes/{0}/folders.json", folderId), requestArg);
         }
         #endregion
 
         #region Conversations
 
-        public Paged<Conversation> ListConversations(int mailboxId, ConversationRequest requestArg = null)
+        public async Task<Paged<Conversation>> ListConversations(int mailboxId, ConversationRequest requestArg = null)
         {
-
             string endpoint = string.Format("mailboxes/{0}/conversations.json", mailboxId);
 
-            return Get<Paged<Conversation>>(endpoint, requestArg);
+            return await Get<Paged<Conversation>>(endpoint, requestArg);
         }
 
-        public Paged<Conversation> ListConversationsInFolder(int mailboxId, int folderId, ConversationRequest requestArg = null)
+        public async Task<Paged<Conversation>> ListConversationsInFolder(int mailboxId, int folderId, ConversationRequest requestArg = null)
         {
             string endpoint = string.Format("mailboxes/{0}/folders/{1}/conversations.json", mailboxId, folderId);
 
-            return Get<Paged<Conversation>>(endpoint, requestArg);
+            return await Get<Paged<Conversation>>(endpoint, requestArg);
         }
 
-        public Paged<Conversation> ListConversationsForCustomer(int mailboxId, int customerId, ConversationRequest requestArg = null)
+        public async Task<Paged<Conversation>> ListConversationsForCustomer(int mailboxId, int customerId, ConversationRequest requestArg = null)
         {
             string endpoint = string.Format("mailboxes/{0}/customers/{1}/conversations.json", mailboxId, customerId);
 
-            return Get<Paged<Conversation>>(endpoint, requestArg);
+            return await Get<Paged<Conversation>>(endpoint, requestArg);
         }
 
-        public Paged<Conversation> ListConversationsForUser(int mailboxId, int userId, FieldRequest requestArg = null)
+        public async Task<Paged<Conversation>> ListConversationsForUser(int mailboxId, int userId, FieldRequest requestArg = null)
         {
             string endpoint = string.Format("mailboxes/{0}/customers/{1}/conversations.json", mailboxId, userId);
-            return Get<Paged<Conversation>>(endpoint, requestArg);
+            return await Get<Paged<Conversation>>(endpoint, requestArg);
         }
 
-        public Conversation GetConversation(int conversationId, FieldRequest requestArg = null)
+        public async Task<SingleItem<Conversation>> GetConversation(int conversationId, FieldRequest requestArg = null)
         {
             string endpoint = string.Format("conversations/{0}.json", conversationId);
-            return Get<SingleItem<Conversation>>(endpoint, requestArg).Item;
+            return await Get<SingleItem<Conversation>>(endpoint, requestArg);
         }
 
-        public Attachment GetAttachement(int conversationId, FieldRequest requestArg = null)
+        public async Task<SingleItem<Attachment>> GetAttachement(int conversationId, FieldRequest requestArg = null)
         {
             string endpoint = string.Format("attachments/{0}/data.json", conversationId);
-            return Get<SingleItem<Attachment>>(endpoint, requestArg).Item;
+            return await Get<SingleItem<Attachment>>(endpoint, requestArg);
         }
 
-        public Conversation CreateConversation(Conversation conversation, bool imported = false, bool autoReply = false, bool reload = true)
+        public async Task<Conversation> CreateConversation(Conversation conversation, bool imported = false, bool autoReply = false, bool reload = true)
         {
             string endpoint = "conversations.json";
-            return Post(endpoint, conversation, new CreateCustomerRequest { AutoReply = autoReply, Reload = reload, Imported = imported });
+            return await Post(endpoint, conversation, new CreateCustomerRequest { AutoReply = autoReply, Reload = reload, Imported = imported });
         }
 
-        public Conversation UpdateConversation(Conversation conversation, bool reload = true)
+        public async Task<Conversation> UpdateConversation(Conversation conversation, bool reload = true)
         {
             string endpoint = string.Format("conversations/{0}.json", conversation.Id);
-            return Put(endpoint, conversation, new PostOrPutRequest { Reload = reload });
+            return await Put(endpoint, conversation, new PostOrPutRequest { Reload = reload });
         }
 
         public void DeleteConversation(int id)
@@ -136,18 +137,18 @@ namespace HelpScoutNet
             Delete(endpoint);
         }
 
-        public Thread CreateThread(int conversationId, Thread thread, bool imported = false, bool reload = true)
+        public async Task<Thread> CreateThread(int conversationId, Thread thread, bool imported = false, bool reload = true)
         {
             string endpoint = string.Format("conversations/{0}.json", conversationId);
 
-            return Post(endpoint, thread, new PostOrPutRequest { Reload = reload, Imported = imported });
+            return await Post(endpoint, thread, new PostOrPutRequest { Reload = reload, Imported = imported });
         }
 
-        public string CreateAttachment(CreateAttachmentRequest request)
+        public async Task<string> CreateAttachment(CreateAttachmentRequest request)
         {
             string endpoint = "attachments.json";
 
-            return PostAttachment(endpoint, request);
+            return await PostAttachment(endpoint, request);
         }
 
         public void DeleteAttachment(string id)
@@ -161,25 +162,25 @@ namespace HelpScoutNet
 
         #region Customers
 
-        public Paged<Customer> ListCustomers(CustomerRequest requestArg = null)
+        public async Task<Paged<Customer>> ListCustomers(CustomerRequest requestArg = null)
         {
             string endpoint = "customers.json";
 
-            return Get<Paged<Customer>>(endpoint, requestArg);
+            return await Get<Paged<Customer>>(endpoint, requestArg);
         }
 
-        public Paged<Customer> ListCustomers(int mailboxId, CustomerRequest requestArg = null)
+        public async Task<Paged<Customer>> ListCustomers(int mailboxId, CustomerRequest requestArg = null)
         {
             string endpoint = string.Format("mailbox/{0}/customers.json", mailboxId);
 
-            return Get<Paged<Customer>>(endpoint, requestArg);
+            return await Get<Paged<Customer>>(endpoint, requestArg);
         }
 
-        public Customer GetCustomer(int customerId, CustomerRequest requestArg = null)
+        public async Task<SingleItem<Customer>> GetCustomer(int customerId, CustomerRequest requestArg = null)
         {
             string endpoint = string.Format("customers/{0}.json", customerId);
 
-            return Get<SingleItem<Customer>>(endpoint, requestArg).Item;
+            return await Get<SingleItem<Customer>>(endpoint, requestArg);
         }
 
         /// <summary>
@@ -188,11 +189,11 @@ namespace HelpScoutNet
         /// <param name="customer"></param>
         /// <param name="reload">if true return the new customer otherwise return the original customer</param>
         /// <returns>if reload is true return the new customer otherwise return the original customer</returns>
-        public Customer CreateCustomer(Customer customer, bool reload = true)
+        public async Task<Customer> CreateCustomer(Customer customer, bool reload = true)
         {
             string endpoint = "customers.json";
 
-            return Post(endpoint, customer, new PostOrPutRequest { Reload = reload });
+            return await Post(endpoint, customer, new PostOrPutRequest { Reload = reload });
         }
 
         /// <summary>
@@ -202,28 +203,28 @@ namespace HelpScoutNet
         /// <param name="customer">customer data to update</param>
         /// <param name="reload">if true return the new customer otherwise return the original customer</param>
         /// <returns>if reload is true return the new customer otherwise return the original customer</returns>
-        public Customer UpdateCustomer(int customerId, Customer customer, bool reload = true)
+        public async Task<Customer> UpdateCustomer(int customerId, Customer customer, bool reload = true)
         {
             string endpoint = string.Format("customers/{0}.json", customerId);
 
-            return Put(endpoint, customer, new PostOrPutRequest { Reload = reload });
+            return await Put(endpoint, customer, new PostOrPutRequest { Reload = reload });
         }
         #endregion
 
         #region Search
 
-        public Paged<SearchConversation> SearchConversations(SearchRequest requestArg = null)
+        public async Task<Paged<SearchConversation>> SearchConversations(SearchRequest requestArg = null)
         {
             string endpoint = "search/conversations.json";
 
-            return Get<Paged<SearchConversation>>(endpoint, requestArg);
+            return await Get<Paged<SearchConversation>>(endpoint, requestArg);
         }
 
-        public Paged<SearchCustomer> SearchCustomers(SearchRequest requestArg = null)
+        public async Task<Paged<SearchCustomer>> SearchCustomers(SearchRequest requestArg = null)
         {
             string endpoint = "search/customers.json";
 
-            return Get<Paged<SearchCustomer>>(endpoint, requestArg);
+            return await Get<Paged<SearchCustomer>>(endpoint, requestArg);
         }
 
 
@@ -231,54 +232,54 @@ namespace HelpScoutNet
 
         #region Tag
 
-        public Paged<HelpScoutNet.Model.Tag> ListTags(PageRequest requestArg = null)
+        public async Task<Paged<HelpScoutNet.Model.Tag>> ListTags(PageRequest requestArg = null)
         {
             string endpoint = "tags.json";
 
-            return Get<Paged<HelpScoutNet.Model.Tag>>(endpoint, requestArg);
+            return await Get<Paged<HelpScoutNet.Model.Tag>>(endpoint, requestArg);
         }
 
         #endregion
 
         #region Users
 
-        public Paged<HelpScoutNet.Model.User> ListUsers(PageRequest requestArg = null)
+        public async Task<Paged<HelpScoutNet.Model.User>> ListUsers(PageRequest requestArg = null)
         {
             string endpoint = "users.json";
 
-            return Get<Paged<HelpScoutNet.Model.User>>(endpoint, requestArg);
+            return await Get<Paged<HelpScoutNet.Model.User>>(endpoint, requestArg);
         }
 
-        public HelpScoutNet.Model.User GetUser(int userId, FieldRequest requestArg)
+        public async Task<SingleItem<HelpScoutNet.Model.User>> GetUser(int userId, FieldRequest requestArg)
         {
             string endpoint = string.Format("users/{0}.json", userId);
 
-            return Get<SingleItem<HelpScoutNet.Model.User>>(endpoint, requestArg).Item;
+            return await Get<SingleItem<HelpScoutNet.Model.User>>(endpoint, requestArg);
         }
 
-        public HelpScoutNet.Model.User GetMe(FieldRequest requestArg)
+        public async Task<SingleItem<HelpScoutNet.Model.User>> GetMe(FieldRequest requestArg)
         {
             string endpoint = "users/me.json";
 
-            return Get<SingleItem<HelpScoutNet.Model.User>>(endpoint, requestArg).Item;
+            return await Get<SingleItem<HelpScoutNet.Model.User>>(endpoint, requestArg);
         }
 
-        public Paged<HelpScoutNet.Model.User> ListUserPerMailbox(int mailboxId, FieldRequest requestArg)
+        public async Task<Paged<HelpScoutNet.Model.User>> ListUserPerMailbox(int mailboxId, FieldRequest requestArg)
         {
             string endpoint = string.Format("mailboxes/{0}/users.json", mailboxId);
 
-            return Get<Paged<HelpScoutNet.Model.User>>(endpoint, requestArg);
+            return await Get<Paged<HelpScoutNet.Model.User>>(endpoint, requestArg);
         }
 
         #endregion
 
         #region Workflows
 
-        public Paged<Workflow> ListWorkflows(int mailboxId, FieldRequest requestArg)
+        public async Task<Paged<Workflow>> ListWorkflows(int mailboxId, FieldRequest requestArg)
         {
             string endpoint = string.Format("mailboxes/{0}/workflows.json", mailboxId);
 
-            return Get<Paged<Workflow>>(endpoint, requestArg);
+            return await Get<Paged<Workflow>>(endpoint, requestArg);
         }
 
         #endregion
@@ -286,46 +287,46 @@ namespace HelpScoutNet
         #region Reports
 
         #region Users
-        public Model.Report.User.UserReports.UserReport GetUserOverallReport(Request.Report.User.UserRequest requestArg)
+        public async Task<Model.Report.User.UserReports.UserReport> GetUserOverallReport(Request.Report.User.UserRequest requestArg)
         {
             string endpoint = string.Format("reports/user.json");
-            return Get<Model.Report.User.UserReports.UserReport>(endpoint, requestArg);
+            return await Get<Model.Report.User.UserReports.UserReport>(endpoint, requestArg);
         }
 
-        public Model.Report.PagedReport<Model.Report.User.ConversationStats> GetUserConversationHistory(Request.Report.User.UserPagedRequest requestArg)
+        public async Task<Model.Report.PagedReport<Model.Report.User.ConversationStats>> GetUserConversationHistory(Request.Report.User.UserPagedRequest requestArg)
         {
             string endpoint = string.Format("reports/user/conversation-history.json");
-            return Get<Model.Report.PagedReport<Model.Report.User.ConversationStats>>(endpoint, requestArg);
+            return await Get<Model.Report.PagedReport<Model.Report.User.ConversationStats>>(endpoint, requestArg);
         }
 
-        public Model.Report.Common.CustomersDatesAndCounts GetUserCustomersHelped(Request.Report.User.UserViewByRequest requestArg)
+        public async Task<Model.Report.Common.CustomersDatesAndCounts> GetUserCustomersHelped(Request.Report.User.UserViewByRequest requestArg)
         {
             string endpoint = string.Format("reports/user/customers-helped.json");
-            return Get<Model.Report.Common.CustomersDatesAndCounts>(endpoint, requestArg);
+            return await Get<Model.Report.Common.CustomersDatesAndCounts>(endpoint, requestArg);
         }
 
-        public Model.Report.Common.RepliesDatesAndCounts GetUserReplies(Request.Report.User.UserViewByRequest requestArg)
+        public async Task<Model.Report.Common.RepliesDatesAndCounts> GetUserReplies(Request.Report.User.UserViewByRequest requestArg)
         {
             string endpoint = string.Format("reports/user/replies.json");
-            return Get<Model.Report.Common.RepliesDatesAndCounts>(endpoint, requestArg);
+            return await Get<Model.Report.Common.RepliesDatesAndCounts>(endpoint, requestArg);
         }
 
-        public Model.Report.Common.ResolvedDatesAndCounts GetUserResolved(Request.Report.User.UserViewByRequest requestArg)
+        public async Task<Model.Report.Common.ResolvedDatesAndCounts> GetUserResolved(Request.Report.User.UserViewByRequest requestArg)
         {
             string endpoint = string.Format("reports/user/resolutions.json");
-            return Get<Model.Report.Common.ResolvedDatesAndCounts>(endpoint, requestArg);
+            return await Get<Model.Report.Common.ResolvedDatesAndCounts>(endpoint, requestArg);
         }
 
-        public Model.Report.User.UserHappiness GetUserHappiness(Request.Report.User.UserRequest requestArg)
+        public async Task<Model.Report.User.UserHappiness> GetUserHappiness(Request.Report.User.UserRequest requestArg)
         {
             string endpoint = string.Format("reports/user/happiness.json");
-            return Get<Model.Report.User.UserHappiness>(endpoint, requestArg);
+            return await Get<Model.Report.User.UserHappiness>(endpoint, requestArg);
         }
 
-        public Model.Report.PagedReport<Model.Report.Common.Rating> GetUserRatings(Request.Report.User.UserRatingsRequest requestArg)
+        public async Task<Model.Report.PagedReport<Model.Report.Common.Rating>> GetUserRatings(Request.Report.User.UserRatingsRequest requestArg)
         {
             string endpoint = string.Format("reports/user/ratings.json");
-            return Get<PagedReport<Model.Report.Common.Rating>>(endpoint, requestArg);
+            return await Get<PagedReport<Model.Report.Common.Rating>>(endpoint, requestArg);
         }
 
         private void GetUserDrillDown()
@@ -337,10 +338,10 @@ namespace HelpScoutNet
 
         #region Conversations
 
-        public Model.Report.Conversations.ConversationsReport GetConversationsOverall(Request.Report.CompareRequest requestArg)
+        public async Task<Model.Report.Conversations.ConversationsReport> GetConversationsOverall(Request.Report.CompareRequest requestArg)
         {
             string endpoint = string.Format("reports/conversations.json");
-            return Get<Model.Report.Conversations.ConversationsReport>(endpoint, requestArg);
+            return await Get<Model.Report.Conversations.ConversationsReport>(endpoint, requestArg);
         }
 
         private void GetNewConversations()
@@ -367,10 +368,10 @@ namespace HelpScoutNet
 
         #region Team
 
-        public Model.Report.Team.TeamReport GetTeamOverall(Request.Report.CompareRequest requestArg)
+        public async Task<Model.Report.Team.TeamReport> GetTeamOverall(Request.Report.CompareRequest requestArg)
         {
             string endpoint = string.Format("reports/team.json");
-            return Get<Model.Report.Team.TeamReport>(endpoint, requestArg);
+            return await Get<Model.Report.Team.TeamReport>(endpoint, requestArg);
         }
 
         private void GetTeamCustomersHelped()
@@ -387,16 +388,16 @@ namespace HelpScoutNet
 
         #region Happiness
 
-        private Model.Report.Happiness.HappinessReport GetHappinessOverall(Request.Report.CompareRequest requestArg)
+        private async Task<Model.Report.Happiness.HappinessReport> GetHappinessOverall(Request.Report.CompareRequest requestArg)
         {
             string endpoint = string.Format("reports/happiness.json");
-            return Get<Model.Report.Happiness.HappinessReport>(endpoint, requestArg);
+            return await Get<Model.Report.Happiness.HappinessReport>(endpoint, requestArg);
         }
 
-        private Paged<Model.Report.Common.Rating> GetHappinessRatings(Request.Report.PagedRatingsRequest requestArg)
+        private async Task<Paged<Model.Report.Common.Rating>> GetHappinessRatings(Request.Report.PagedRatingsRequest requestArg)
         {
             string endpoint = string.Format("reports/happiness/ratings.json");
-            return Get<Paged<Model.Report.Common.Rating>>(endpoint, requestArg);
+            return await Get<Paged<Model.Report.Common.Rating>>(endpoint, requestArg);
         }
 
         #endregion
@@ -502,7 +503,7 @@ namespace HelpScoutNet
                 {
                     if (request.Reload)
                     {
-                        T result = JsonConvert.DeserializeObject<SingleItem<T>>(body).Item;
+                        T result = await JsonConvert.DeserializeObject<SingleItem<T>>(body).Item;
                         return result;
                     }
                     else
@@ -516,21 +517,21 @@ namespace HelpScoutNet
             }  
         }
 
-        private T Put<T>(string endpoint, T payload, IPostOrPutRequest request)
+        private async Task<T> Put<T>(string endpoint, T payload, IPostOrPutRequest request)
         {
             using (HttpClient client = InitHttpClient())
             {
                 client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 var jsonPayload = JsonConvert.SerializeObject(payload, _serializerSettings);
 
-                HttpResponseMessage response = client.PutAsync(BaseUrl + endpoint + ToQueryString(request), new StringContent(jsonPayload, Encoding.UTF8, "application/json")).Result;
-                string body = response.Content.ReadAsStringAsync().Result;
+                HttpResponseMessage response = await client.PutAsync(BaseUrl + endpoint + ToQueryString(request), new StringContent(jsonPayload, Encoding.UTF8, "application/json"));
+                string body = await response.Content.ReadAsStringAsync();
 
                 if (response.IsSuccessStatusCode)
                 {
                     if (request.Reload)
                     {
-                        T result = JsonConvert.DeserializeObject<SingleItem<T>>(body).Item;
+                        T result = await JsonConvert.DeserializeObject<SingleItem<T>>(body).Item;
                         return result;
                     }
                     else

--- a/src/HelpScoutNet.csproj
+++ b/src/HelpScoutNet.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Request\PageRequest.cs" />
     <Compile Include="Request\Report\CompareRequest.cs" />
     <Compile Include="Request\Report\PagedCompareRequest.cs" />
+    <Compile Include="Request\Report\PagedRatingsRequest.cs" />
     <Compile Include="Request\Report\ReportRequest.cs" />
     <Compile Include="Request\Report\User\UserPagedRequest.cs" />
     <Compile Include="Request\Report\User\UserRatingsRequest.cs" />

--- a/src/HelpScoutNet.csproj
+++ b/src/HelpScoutNet.csproj
@@ -30,6 +30,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\FCRApps\HelpScoutMetrics\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />

--- a/src/Model/Report/Common/Rating.cs
+++ b/src/Model/Report/Common/Rating.cs
@@ -15,6 +15,11 @@ namespace HelpScoutNet.Model.Report.Common
         public ConversationType Type { get; set; }
         public int ThreadID { get; set; }
         public DateTime? ThreadCreatedAt { get; set; }
+        /// <summary>
+        /// 1 = Great
+        /// 2 = OK
+        /// 3 = Bad
+        /// </summary>
         public int RatingID { get; set; }
         public int RatingCustomerID { get; set; }
         public string RatingComments { get; set; }

--- a/src/Model/SingleItem.cs
+++ b/src/Model/SingleItem.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HelpScoutNet.Model
+{
+    internal class SingleItem <T>
+    {
+        public T Item { get; set; }
+
+    }
+}

--- a/src/Model/SingleItem.cs
+++ b/src/Model/SingleItem.cs
@@ -8,7 +8,7 @@ namespace HelpScoutNet.Model
 {
     internal class SingleItem <T>
     {
-        public T Item { get; set; }
+        public Task<T> Item { get; set; }
 
     }
 }

--- a/src/Request/Report/PagedRatingsRequest.cs
+++ b/src/Request/Report/PagedRatingsRequest.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HelpScoutNet.Request.Report
+{
+    public class PagedRatingsRequest : ReportRequest
+    {
+        public PagedRatingsRequest(DateTime? startTime, DateTime? endTime, int rating)
+                : base(startTime, endTime)
+        {
+
+        }
+
+        public int? Rating { get; set; }
+        public int? Page { get; set; }
+        /// <summary>
+        /// Valid input: number, modifiedAt, rating
+        /// </summary>
+        public string SortField { get; set; }
+        /// <summary>
+        /// Valid input: ASC or DESC
+        /// </summary>
+        public string SortOrder { get; set; }
+
+        public override NameValueCollection ToNameValueCollection()
+        {
+            base.ToNameValueCollection();
+            if (Page.HasValue)
+                Nv.Add("page", Page.ToString());
+            if (Rating.HasValue)
+                Nv.Add("rating", Rating.ToString());
+            if (!string.IsNullOrEmpty(SortField))
+                Nv.Add("sortfield", SortField.ToString());
+            if (!string.IsNullOrEmpty(SortOrder))
+                Nv.Add("sortorder", SortOrder.ToString());
+            return Nv;
+        }
+    }
+}

--- a/src/Request/Report/PagedRatingsRequest.cs
+++ b/src/Request/Report/PagedRatingsRequest.cs
@@ -12,7 +12,7 @@ namespace HelpScoutNet.Request.Report
         public PagedRatingsRequest(DateTime? startTime, DateTime? endTime, int rating)
                 : base(startTime, endTime)
         {
-
+            Rating = rating;
         }
 
         public int? Rating { get; set; }


### PR DESCRIPTION
I added an async client that can be instantiated as `HelpScoutMetricsAsync`. I also moved the single item class to it's own file since two classes are now coupled to it. I also added a timeout option as a constructor that will set the timeout for the HTTPClient, no value means no timeout.

I also moved all HTTPClient relevant code into using statements to automatically dispose of the client when I am done with it.

I was having issues with deadlocks when burst calling the API (deadlocks within a few seconds when making request every 25ms), and with lots of requests (10,000+) where it would eventually run into a deadlock condition. I was unable to fix the HTTPClient, my HTTP request knowledge is lacking. I opted to make an async client that any user can await.

I currently have a pretty solid API call queue I've implemented that if ever polished I will try and integrate into the API as an optional way to queue and throttle API requests.