### PR TITLE
Fix PostalCode property name for proper deserialization

### DIFF
--- a/src/Model/Customer.cs
+++ b/src/Model/Customer.cs
@@ -13,7 +13,7 @@ namespace HelpScoutNet.Model
         public List<string> Lines { get; set; }
         public string City { get; set; }
         public string State { get; set; }
-        public string PostcalCode { get; set; }
+        public string PostalCode { get; set; }
         public string Country { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
Hello,
There was a typo in the name of the PostalCode property on the Customer object.  As a result, when pulling customer information from HelpScout, the PostalCode property never has a value.

Can you merge this into your project?

Thanks,
Mark