### PR TITLE
Fixes population of ConversationDetail.Links

### DIFF
--- a/HelpScoutClient/Conversations/Models/Detail/ConversationDetail.cs
+++ b/HelpScoutClient/Conversations/Models/Detail/ConversationDetail.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace HelpScout.Conversations.Models.Detail
 {
@@ -28,6 +29,7 @@ namespace HelpScout.Conversations.Models.Detail
         public IList<string> Bcc { get; set; }
         public PrimaryCustomer PrimaryCustomer { get; set; }
         public IList<CustomField> CustomFields { get; set; }
+        [JsonProperty("_Links")]
         public Links Links { get; set; }
     }
 }


### PR DESCRIPTION
The Links property of ConversationDetail was not being populated, as the API was returning "_links" in the json, rather than "links".

Added underscore to ConversationDetail Links property name for json parsing, to match what the API returns.